### PR TITLE
fix: SUSPEND modifier for streaming calls only

### DIFF
--- a/plugin/src/main/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generate_mulitplatform_sources/generators/service/ServiceWriter.kt
+++ b/plugin/src/main/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generate_mulitplatform_sources/generators/service/ServiceWriter.kt
@@ -49,7 +49,11 @@ abstract class ServiceWriter(private val isActual: Boolean) {
                             addFunction(
                                 FunSpec
                                     .builder(rpc.rpcName)
-                                    .addModifiers(KModifier.SUSPEND)
+                                    .apply {
+                                        if (rpc.method == ProtoRpc.Method.UNARY) {
+                                            this.addModifiers(KModifier.SUSPEND)
+                                        }
+                                    }
                                     .addModifiers(classAndFunctionModifiers)
                                     .addParameter(Const.Service.RpcCall.PARAM_REQUEST, rpc.request.commonType)
                                     .addParameter(


### PR DESCRIPTION
The rpc calls marked as  returns stream * should not be marked as suspend since they return a flow.