### PR TITLE
Add support for name conflict resolution

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -111,6 +111,7 @@ jobs:
           key: lib-cocoapods-synthetic-${{ runner.os }}-${{ hashFiles('kmp-grpc-core/gradle.properties') }}
 
       - name: Wait for test-server to be healthy
+        timeout-minutes: 10
         run: |
           echo "Waiting for service..."
           while ! grpcurl -plaintext localhost:17888 io.github.timortel.kmpgrpc.test.TestService/emptyRpc | grep -q "{}"; do

--- a/kmp-grpc-internal-test/src/commonMain/proto/conflictingMessages.proto
+++ b/kmp-grpc-internal-test/src/commonMain/proto/conflictingMessages.proto
@@ -13,11 +13,6 @@ message MessageWithReservedFields {
   string fullName = 2;
 }
 
-message MessageWithMapClash {
-  map<string, string> a = 1;
-  string aMap = 2;
-}
-
 message MessageWithListClash {
   repeated string a = 1;
   string aList = 2;

--- a/kmp-grpc-internal-test/src/commonMain/proto/conflictingMessages.proto
+++ b/kmp-grpc-internal-test/src/commonMain/proto/conflictingMessages.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package io.github.timortel.kmpgrpc.test;
+
+option java_multiple_files = true;
+
+message MessageWithMessage {
+  string message = 1;
+}
+
+message MessageWithReservedFields {
+  int32 requiredSize = 1;
+  string fullName = 2;
+}
+
+message MessageWithMapClash {
+  map<string, string> a = 1;
+  string aMap = 2;
+}
+
+message MessageWithListClash {
+  repeated string a = 1;
+  string aList = 2;
+}
+
+message MessageWithIsFieldSetClash {
+  optional string a = 1;
+  bool isASet = 2;
+}

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/constants/Const.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/constants/Const.kt
@@ -29,6 +29,8 @@ object Const {
     }
 
     object Message {
+        val reservedAttributeNames = setOf("fullName", "requiredSize")
+
         val fullNameProperty = Property("fullName", STRING)
 
         object SerializeFunction {
@@ -37,6 +39,8 @@ object Const {
         }
 
         object OneOf {
+            val reservedAttributeNames = setOf("requiredSize")
+
             const val REQUIRED_SIZE_PROPERTY_NAME = "requiredSize"
 
             const val SERIALIZE_FUNCTION_NAME = "serialize"

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/ProtoFieldWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/ProtoFieldWriter.kt
@@ -17,7 +17,7 @@ abstract class ProtoFieldWriter {
 
     fun addMessageField(builder: TypeSpec.Builder, field: ProtoMessageField) {
         when (field.cardinality) {
-            is ProtoFieldCardinality.Singular -> singularProtoFieldWriter.addField(builder, field, field.cardinality)
+            is ProtoFieldCardinality.Singular -> singularProtoFieldWriter.addField(builder, field)
             ProtoFieldCardinality.Repeated -> repeatedProtoFieldWriter.addField(builder, field)
         }
     }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/map/ProtoMapFieldWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/map/ProtoMapFieldWriter.kt
@@ -15,6 +15,7 @@ abstract class ProtoMapFieldWriter {
                     field.attributeName,
                     MAP.parameterizedBy(field.keyType.resolve(), field.valuesType.resolve())
                 )
+                .addKdoc(field.infoText)
                 .apply {
                     modifyMapProperty(this, field)
                 }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/repeated/RepeatedProtoFieldWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/repeated/RepeatedProtoFieldWriter.kt
@@ -14,6 +14,7 @@ abstract class RepeatedProtoFieldWriter {
                 field.attributeName,
                 LIST.parameterizedBy(field.type.resolve())
             )
+            .addKdoc(field.infoText)
             .addModifiers(attrs)
             .apply { modifyListProperty(this, field) }
             .build()

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/singular/ActualSingularProtoFieldWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/singular/ActualSingularProtoFieldWriter.kt
@@ -10,13 +10,13 @@ object ActualSingularProtoFieldWriter : SingularProtoFieldWriter() {
 
     override fun PropertySpec.Builder.modifyProperty(field: ProtoMessageField) {
         if (field.type is ProtoType.DefType && field.type.isMessage) {
-            initializer("%N ?: %T()", field.name, field.type.resolve())
+            initializer("%N ?: %T()", field.attributeName, field.type.resolve())
         } else {
-            initializer(field.name)
+            initializer(field.attributeName)
         }
     }
 
     override fun PropertySpec.Builder.modifyIsSetProperty(field: ProtoMessageField) {
-        initializer("%N != null", field.name)
+        initializer("%N != null", field.attributeName)
     }
 }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/singular/SingularProtoFieldWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/field/singular/SingularProtoFieldWriter.kt
@@ -1,19 +1,18 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.protofile.field.singular
 
 import com.squareup.kotlinpoet.*
-import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
-import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoFieldCardinality
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoMessageField
 
 abstract class SingularProtoFieldWriter {
 
     protected abstract val attrs: List<KModifier>
 
-    fun addField(builder: TypeSpec.Builder, field: ProtoMessageField, cardinality: ProtoFieldCardinality.Singular) {
+    fun addField(builder: TypeSpec.Builder, field: ProtoMessageField) {
         with(builder) {
             addProperty(
                 PropertySpec
-                    .builder(field.name, field.type.resolve())
+                    .builder(field.attributeName, field.type.resolve())
+                    .addKdoc(field.infoText)
                     .addModifiers(attrs)
                     .apply {
                         modifyProperty(field)
@@ -21,12 +20,12 @@ abstract class SingularProtoFieldWriter {
                     .build()
             )
 
-            // See https://protobuf.dev/programming-guides/field_presence/#presence-in-proto3-apis
-            // The "isSet" method is added for optional fields and message types.
-            if (cardinality is ProtoFieldCardinality.Optional || field.type is ProtoType.DefType && field.type.isMessage) {
+
+            if (field.needsIsSetProperty) {
                 addProperty(
                     PropertySpec
-                        .builder(field.isSetPropertyName, BOOLEAN)
+                        .builder(field.isSetProperty.attributeName, BOOLEAN)
+                        .addKdoc(field.infoText)
                         .addModifiers(attrs)
                         .apply { modifyIsSetProperty(field) }
                         .build()

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/RequiredSizePropertyExtension.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/RequiredSizePropertyExtension.kt
@@ -34,7 +34,7 @@ class RequiredSizePropertyExtension : BaseSerializationExtension() {
                 val fieldsCodeBlock = message.fields.joinToCodeBlock(separator) { field ->
                     when {
                         field.cardinality == ProtoFieldCardinality.Optional || (field.type.isMessage && field.cardinality != ProtoFieldCardinality.Repeated) -> {
-                            add("if·(%N)·{·", field.isSetPropertyName)
+                            add("if·(%N)·{·", field.isSetProperty.attributeName)
                             add(getCodeForRequiredSizeForScalarAttributeC(field))
                             add("}·else·{·0·}")
                         }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/SerializationFunctionExtension.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/SerializationFunctionExtension.kt
@@ -9,6 +9,7 @@ import io.github.timortel.kmpgrpc.plugin.sourcegeneration.constants.*
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoMessage
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoFieldCardinality
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoMapField
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoMessageField
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoRegularField
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
 
@@ -258,10 +259,10 @@ class SerializationFunctionExtension : BaseSerializationExtension() {
                     when (type.declType) {
                         ProtoType.DefType.DeclarationType.MESSAGE -> {
                             CodeBlock.builder().apply {
-                                if (performIsFieldSetCheck) {
+                                if (performIsFieldSetCheck && field is ProtoMessageField) {
                                     beginControlFlow(
                                         "if (%N)",
-                                        field.isSetPropertyName
+                                        field.isSetProperty.attributeName
                                     )
                                 }
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoChildProperty.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoChildProperty.kt
@@ -1,0 +1,30 @@
+package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration
+
+/**
+ * Base interface of a proto property of a generated class.
+ */
+interface ProtoChildProperty {
+
+    val resolvingParent: ProtoChildPropertyNameResolver
+
+    /**
+     * The name of the property as defined in the proto source code
+     */
+    val name: String
+
+    /**
+     * The name of the field the property would like to have if there were not any clashes
+     */
+    val desiredAttributeName: String
+
+    /**
+     * The name of the field in the generated message class
+     */
+    val attributeName: String
+        get() = resolvingParent.resolveMessagePropertyName(this)
+
+    /**
+     * The priority of this child property in the context of name clash resolution.
+     */
+    val priority: Int
+}

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoChildPropertyNameResolver.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoChildPropertyNameResolver.kt
@@ -1,0 +1,35 @@
+package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration
+
+/**
+ * Parent interface of [ProtoMessage] and [io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoOneOf].
+ *
+ * Used to resolve the property name of a proto property in the generated code and to avoid name clashes.
+ */
+interface ProtoChildPropertyNameResolver {
+
+    val reservedAttributeNames: Set<String>
+
+    val childProperties: List<ProtoChildProperty>
+
+    fun resolveMessagePropertyName(field: ProtoChildProperty): String {
+        val reservedNames = reservedAttributeNames.toMutableSet()
+        val nameMap: MutableMap<ProtoChildProperty, String> = mutableMapOf()
+
+        childProperties
+            .sortedBy { it.priority }
+            .forEach { currentField ->
+                var attributeName = currentField.desiredAttributeName
+
+                while (attributeName in reservedNames) {
+                    attributeName = "${attributeName}_"
+                }
+
+                if (currentField == field) return attributeName
+
+                reservedNames += attributeName
+                nameMap[currentField] = attributeName
+            }
+
+        throw IllegalArgumentException("field=$field not child of resolver=$this. Known children=$childProperties.")
+    }
+}

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoMessage.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoMessage.kt
@@ -1,6 +1,7 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration
 
 import com.squareup.kotlinpoet.MemberName
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.constants.Const
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.*
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoOneOf
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoReservation
@@ -11,6 +12,9 @@ import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.util.decapitalize
 import org.antlr.v4.runtime.ParserRuleContext
 
+/**
+ * Representation of a proto message.
+ */
 data class ProtoMessage(
     override val name: String,
     val messages: List<ProtoMessage>,
@@ -21,7 +25,7 @@ data class ProtoMessage(
     override val reservation: ProtoReservation,
     override val options: List<ProtoOption>,
     override val ctx: ParserRuleContext
-) : ProtoDeclaration, FileBasedDeclarationResolver, ProtoFieldHolder {
+) : ProtoDeclaration, FileBasedDeclarationResolver, ProtoFieldHolder, ProtoChildPropertyNameResolver {
 
     override lateinit var parent: ProtoDeclParent
 
@@ -61,6 +65,12 @@ data class ProtoMessage(
 
     val dslBuildFunction: MemberName
         get() = MemberName(file.javaPackage, name.decapitalize())
+
+    override val childProperties: List<ProtoChildProperty>
+        get() = fields + mapFields + oneOfs + fields.flatMap { it.childProperties }
+
+    override val reservedAttributeNames: Set<String>
+        get() = Const.Message.reservedAttributeNames
 
     init {
         val parent = ProtoDeclParent.Message(this)

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/ProtoMessageProperty.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/ProtoMessageProperty.kt
@@ -1,13 +1,16 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message
 
-interface ProtoMessageProperty {
-    /**
-     * The name of the property as defined in the proto source code
-     */
-    val name: String
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildProperty
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildPropertyNameResolver
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoMessage
+
+interface ProtoMessageProperty : ProtoChildProperty {
 
     /**
-     * The name of the field in the generated message class
+     * The parent of this property
      */
-    val attributeName: String
+    val message: ProtoMessage
+
+    override val resolvingParent: ProtoChildPropertyNameResolver
+        get() = message
 }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/ProtoOneOf.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/ProtoOneOf.kt
@@ -1,10 +1,13 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message
 
 import com.squareup.kotlinpoet.ClassName
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.constants.Const
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoNode
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.util.capitalize
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoOption
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildProperty
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildPropertyNameResolver
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoMessage
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoOneOfField
 
@@ -12,13 +15,13 @@ data class ProtoOneOf(
     override val name: String,
     val fields: List<ProtoOneOfField>,
     val options: List<ProtoOption>
-) : ProtoMessageProperty, ProtoNode {
+) : ProtoMessageProperty, ProtoNode, ProtoChildPropertyNameResolver {
     companion object {
         private const val UNKNOWN_CLASS_NAME = "Unknown"
         private const val UNSET_CLASS_NAME = "NotSet"
     }
 
-    lateinit var message: ProtoMessage
+    override lateinit var message: ProtoMessage
 
     val file: ProtoFile get() = message.file
 
@@ -27,7 +30,16 @@ data class ProtoOneOf(
     val sealedClassNameNotSet: ClassName get() = sealedClassName.nestedClass(UNSET_CLASS_NAME)
     val sealedClassNameUnknown: ClassName get() = sealedClassName.nestedClass(UNKNOWN_CLASS_NAME)
 
-    override val attributeName: String = name
+    override val desiredAttributeName: String = name
+
+    override val childProperties: List<ProtoChildProperty>
+        get() = fields
+
+    override val reservedAttributeNames: Set<String>
+        get() = Const.Message.OneOf.reservedAttributeNames
+
+    override val priority: Int
+        get() = fields.minOf { it.number }
 
     init {
         fields.forEach { it.parent = this }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoBaseField.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoBaseField.kt
@@ -1,12 +1,21 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field
 
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildProperty
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoField
-import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoMessageProperty
 
-sealed class ProtoBaseField : ProtoMessageProperty, ProtoField {
+sealed class ProtoBaseField : ProtoField, ProtoChildProperty {
     /**
      * The proto number in the message field as defined by the proto source code.
      */
     abstract override val number: Int
     abstract override val name: String
+
+    override val priority: Int
+        get() = number
+
+    /**
+     * Extra info text for KDOC.
+     */
+    val infoText: String
+        get() = "$name = $number"
 }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoMapField.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoMapField.kt
@@ -4,6 +4,7 @@ import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoOption
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoMessage
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoMessageProperty
 import org.antlr.v4.runtime.ParserRuleContext
 
 data class ProtoMapField(
@@ -13,12 +14,12 @@ data class ProtoMapField(
     val keyType: ProtoType.MapKeyType,
     val valuesType: ProtoType,
     override val ctx: ParserRuleContext
-) : ProtoBaseField() {
-    lateinit var message: ProtoMessage
+) : ProtoBaseField(), ProtoMessageProperty {
+    override lateinit var message: ProtoMessage
 
     override val file: ProtoFile get() = message.file
 
-    override val attributeName: String = "${name}Map"
+    override val desiredAttributeName: String = "${name}Map"
 
     init {
         keyType.parent = ProtoType.Parent.MapField(this)

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoOneOfField.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoOneOfField.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.ClassName
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.util.capitalize
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoOption
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoChildPropertyNameResolver
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.ProtoOneOf
 import org.antlr.v4.runtime.ParserRuleContext
@@ -15,11 +16,16 @@ data class ProtoOneOfField(
     override val options: List<ProtoOption>,
     override val ctx: ParserRuleContext
 ) : ProtoRegularField() {
+
     lateinit var parent: ProtoOneOf
 
     override val file: ProtoFile get() = parent.file
 
-    override val attributeName: String = name
+    override val desiredAttributeName: String
+        get() = name
+
+    override val resolvingParent: ProtoChildPropertyNameResolver
+        get() = parent
 
     val sealedClassChildName: ClassName get() = parent.sealedClassName.nestedClass(name.capitalize())
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoRegularField.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/message/field/ProtoRegularField.kt
@@ -1,10 +1,7 @@
 package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field
 
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
-import io.github.timortel.kmpgrpc.plugin.sourcegeneration.util.capitalize
 
 sealed class ProtoRegularField : ProtoBaseField() {
     abstract val type: ProtoType
-
-    val isSetPropertyName: String get() = "is${name.capitalize()}Set"
 }


### PR DESCRIPTION
With this PR, when two properties resolve to use the same name in the generated source code, one of them will be appended with '_' to still allow code compilation. 