### PR TITLE
Improvement: Ignore deprecation on generated sources

### DIFF
--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/DefaultAnnotations.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/DefaultAnnotations.kt
@@ -6,4 +6,8 @@ object DefaultAnnotations {
     val Deprecated = AnnotationSpec.builder(kotlin.Deprecated::class)
         .addMember("%S", "Set deprecated by protobuf option")
         .build()
+
+    val SuppressDeprecation = AnnotationSpec.builder(Suppress::class)
+        .addMember("%S", "DEPRECATION")
+        .build()
 }

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/dsl/ProtoDslWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/dsl/ProtoDslWriter.kt
@@ -3,6 +3,7 @@ package io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.dsl
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.constants.Const
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.DefaultAnnotations
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.ProtoMessage
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration.message.field.ProtoFieldCardinality
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
@@ -13,6 +14,7 @@ abstract class ProtoDslWriter(private val isActual: Boolean) {
     fun generateDslBuilderFile(protoFile: ProtoFile): FileSpec {
         val builder = FileSpec
             .builder(protoFile.javaPackage, protoFile.javaFileName + "Dsl")
+            .addAnnotation(DefaultAnnotations.SuppressDeprecation)
 
         generateDslBuilders(protoFile, builder)
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/ProtoFileWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/ProtoFileWriter.kt
@@ -3,6 +3,7 @@ package io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.protofile
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.DefaultAnnotations
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.protofile.enumeration.ProtoEnumerationWriter
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.protofile.message.ProtoMessageWriter
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.service.ProtoServiceWriter
@@ -19,12 +20,14 @@ abstract class ProtoFileWriter(val isActual: Boolean) {
             val messageFiles = file.messages.map { message ->
                 FileSpec
                     .builder(message.className)
+                    .addAnnotation(DefaultAnnotations.SuppressDeprecation)
                     .addType(protoMessageWriter.generateProtoMessageClass(message))
                     .build()
             }
 
             val serviceFiles = file.services.map { service ->
                 FileSpec.builder(service.className)
+                    .addAnnotation(DefaultAnnotations.SuppressDeprecation)
                     .addType(protoServiceWriter.generateServiceStub(service))
                     .build()
             }
@@ -32,6 +35,7 @@ abstract class ProtoFileWriter(val isActual: Boolean) {
             val enumFiles = if (!isActual) {
                 file.enums.map { enum ->
                     FileSpec.builder(enum.className)
+                        .addAnnotation(DefaultAnnotations.SuppressDeprecation)
                         .addType(protoEnumWriter.generateProtoEnum(enum))
                         .build()
                 }
@@ -41,6 +45,7 @@ abstract class ProtoFileWriter(val isActual: Boolean) {
         } else {
             val file = FileSpec
                 .builder(file.className)
+                .addAnnotation(DefaultAnnotations.SuppressDeprecation)
                 .addType(
                     TypeSpec.classBuilder(file.className)
                         .apply {


### PR DESCRIPTION
Currently, when the proto option deprecated is used, the compiler prints deprecation warnings on generated code. This is not intended as warnings should only be printed on usages of the deprecated fields by the consumer. Therefore, with this PR, all generated sources will ignore deprecations. 