### PR TITLE
Feature: Allow setting generated code visbility

### DIFF
--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/GenerateKmpGrpcSourcesTask.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/GenerateKmpGrpcSourcesTask.kt
@@ -38,6 +38,9 @@ abstract class GenerateKmpGrpcSourcesTask : DefaultTask() {
     @get:Input
     abstract val includeWellKnownTypes: Property<Boolean>
 
+    @get:Input
+    abstract val internalVisibility: Property<Boolean>
+
     @get:OutputDirectories
     val outputFolders: ConfigurableFileCollection = project.objects.fileCollection()
 
@@ -78,7 +81,8 @@ abstract class GenerateKmpGrpcSourcesTask : DefaultTask() {
             jvmOutputFolder = getJVMOutputFolder(project),
             jsOutputFolder = getJSOutputFolder(project),
             wasmJsFolder = getWasmJsOutputFolder(project),
-            nativeOutputDir = getNativeOutputFolder(project)
+            nativeOutputDir = getNativeOutputFolder(project),
+            internalVisibility = internalVisibility.get()
         )
 
         val skipExtensionLibPropName = "io.github.timortel.kmp-grpc.internal.${project.name}.skip-wkt-ext"

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/KmpGrpcExtension.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/KmpGrpcExtension.kt
@@ -4,7 +4,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.jetbrains.kotlin.gradle.targets.js.WASM
 import javax.inject.Inject
 
 open class KmpGrpcExtension @Inject constructor(objects: ObjectFactory) {
@@ -34,6 +33,13 @@ open class KmpGrpcExtension @Inject constructor(objects: ObjectFactory) {
      * Instructs the plugin to download and include the well known proto-types: https://protobuf.dev/reference/protobuf/google.protobuf/
      */
     val includeWellKnownTypes: Property<Boolean> = objects
+        .property(Boolean::class.java)
+        .convention(false)
+
+    /**
+     * If the generated source code should be generated with "internal" visibility. By default, "public" is used.
+     */
+    val internalVisibility: Property<Boolean> = objects
         .property(Boolean::class.java)
         .convention(false)
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/KmpGrpcExtension.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/KmpGrpcExtension.kt
@@ -37,7 +37,7 @@ open class KmpGrpcExtension @Inject constructor(objects: ObjectFactory) {
         .convention(false)
 
     /**
-     * If the generated source code should be generated with "internal" visibility. By default, "public" is used.
+     * If the generated source code should be generated with "internal" visibility by default. By default, "public" is used.
      */
     val internalVisibility: Property<Boolean> = objects
         .property(Boolean::class.java)

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/configuration/GrpcProtobufConfiguration.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/configuration/GrpcProtobufConfiguration.kt
@@ -32,6 +32,7 @@ object GrpcProtobufConfiguration {
             it.sourceFolders.setFrom(kmpGrpcExtension.protoSourceFolders.from)
             it.targetSourcesMap.set(kmpGrpcExtension.targetSourcesMap.get().toMap())
             it.includeWellKnownTypes.set(kmpGrpcExtension.includeWellKnownTypes.get())
+            it.internalVisibility.set(kmpGrpcExtension.internalVisibility.get())
         }
 
         project.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/ProtoSourceGenerator.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/ProtoSourceGenerator.kt
@@ -9,6 +9,7 @@ import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.project.Nat
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.project.JsProtoProjectWriter
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.generators.project.JvmProtoProjectWriter
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoProject
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.Visibility
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.structure.ProtoFolder
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.parsing.Protobuf3ModelBuilderVisitor
@@ -23,6 +24,7 @@ object ProtoSourceGenerator {
         logger: Logger,
         protoFolders: List<InputFile>,
         shouldGenerateTargetMap: Map<String, Boolean>,
+        internalVisibility: Boolean,
         commonOutputFolder: File,
         jvmOutputFolder: File,
         jsOutputFolder: File,
@@ -39,7 +41,12 @@ object ProtoSourceGenerator {
                     ),
         )
 
-        val fileMap = generateProtoFiles(logger, protoFolders, shouldGenerateTargetMapBySourceTarget)
+        val fileMap = generateProtoFiles(
+            logger = logger,
+            protoFolders = protoFolders,
+            shouldGenerateTargetMap = shouldGenerateTargetMapBySourceTarget,
+            internalVisibility = internalVisibility
+        )
 
         fileMap[SourceTarget.Common].writeTo(commonOutputFolder)
         fileMap[SourceTarget.Jvm].writeTo(jvmOutputFolder)
@@ -61,7 +68,8 @@ object ProtoSourceGenerator {
     internal fun generateProtoFiles(
         logger: Logger,
         protoFolders: List<InputFile>,
-        shouldGenerateTargetMap: Map<SourceTarget, Boolean>
+        shouldGenerateTargetMap: Map<SourceTarget, Boolean>,
+        internalVisibility: Boolean
     ): Map<SourceTarget, List<FileSpec>> {
         val folders = protoFolders.mapNotNull { sourceFolder ->
             walkFolder(sourceFolder)
@@ -72,7 +80,8 @@ object ProtoSourceGenerator {
             rootFolder = folders.fold(ProtoFolder("", emptyList(), emptyList())) { l, r ->
                 ProtoFolder(name = "", folders = l.folders + r.folders, files = l.files + r.files)
             },
-            logger = logger
+            logger = logger,
+            defaultVisibility = if (internalVisibility) Visibility.INTERNAL else Visibility.PUBLIC
         )
 
         // Before generating code, validate and print warnings / throw errors

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/dsl/ProtoDslWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/dsl/ProtoDslWriter.kt
@@ -54,6 +54,7 @@ abstract class ProtoDslWriter(private val isActual: Boolean) {
             TypeSpec
                 .classBuilder(dslBuilderClassName)
                 .addModifiers(modifier)
+                .addModifiers(message.visibility.modifier)
                 .primaryConstructor(
                     FunSpec.constructorBuilder()
                         .apply {
@@ -141,6 +142,7 @@ abstract class ProtoDslWriter(private val isActual: Boolean) {
                 .addFunction(
                     FunSpec
                         .builder(Const.DSL.BUILD_FUNCTION_NAME)
+                        .addModifiers(message.visibility.modifier)
                         .addModifiers(modifier)
                         .returns(message.className)
                         .apply { if (isActual) modifyBuildFunction(this, message) }
@@ -167,7 +169,7 @@ abstract class ProtoDslWriter(private val isActual: Boolean) {
             addTopLevelFunction(
                 FunSpec
                     .builder(message.dslBuildFunction)
-                    .addModifiers(KModifier.INLINE)
+                    .addModifiers(KModifier.INLINE, message.visibility.modifier)
                     .addParameter(
                         "builderDsl",
                         LambdaTypeName.get(

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/ProtoFileWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/ProtoFileWriter.kt
@@ -51,7 +51,9 @@ abstract class ProtoFileWriter(val isActual: Boolean) {
                 .addAnnotation(DefaultAnnotations.SuppressDeprecation)
                 .addAnnotation(DefaultAnnotations.OptIntoKmpGrpcInternalApi)
                 .addType(
-                    TypeSpec.classBuilder(file.className)
+                    TypeSpec
+                        .classBuilder(file.className)
+                        .addModifiers(file.visibility.modifier)
                         .apply {
                             addModifiers(if (isActual) KModifier.ACTUAL else KModifier.EXPECT)
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/enumeration/ProtoEnumerationWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/enumeration/ProtoEnumerationWriter.kt
@@ -21,6 +21,7 @@ abstract class ProtoEnumerationWriter(val isActual: Boolean) {
 
         return TypeSpec
             .enumBuilder(protoEnum.className)
+            .addModifiers(protoEnum.visibility.modifier)
             .addSuperinterface(kmEnum)
             .addProperty(
                 PropertySpec

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/ProtoMessageWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/ProtoMessageWriter.kt
@@ -57,6 +57,7 @@ abstract class ProtoMessageWriter(private val isActual: Boolean) {
 
         return TypeSpec
             .classBuilder(message.className)
+            .addModifiers(message.visibility.modifier)
             .apply {
                 when {
                     isActual -> addModifiers(KModifier.ACTUAL)

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/service/ProtoServiceWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/service/ProtoServiceWriter.kt
@@ -23,6 +23,7 @@ abstract class ProtoServiceWriter(private val isActual: Boolean) {
 
         return TypeSpec
             .classBuilder(service.className)
+            .addModifiers(service.visibility.modifier)
             .addModifiers(classAndFunctionModifiers)
             .addFunction(
                 FunSpec

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/ProtoProject.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/ProtoProject.kt
@@ -7,7 +7,11 @@ import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.structure.ProtoP
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.type.ProtoType
 import org.slf4j.Logger
 
-data class ProtoProject(val rootFolder: ProtoFolder, val logger: Logger) : ProtoNode {
+data class ProtoProject(
+    val rootFolder: ProtoFolder,
+    val logger: Logger,
+    val defaultVisibility: Visibility
+) : ProtoNode {
 
     val rootPackage: ProtoPackage
 

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/ProtoVisibilityHolder.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/ProtoVisibilityHolder.kt
@@ -1,0 +1,11 @@
+package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model
+
+interface ProtoVisibilityHolder : ProtoOptionsHolder {
+
+    val project: ProtoProject
+
+    /**
+     * The visibility of the code generated for this declaration or file.
+     */
+    val visibility: Visibility get() = file.project.defaultVisibility
+}

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/Visibility.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/Visibility.kt
@@ -1,0 +1,8 @@
+package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model
+
+import com.squareup.kotlinpoet.KModifier
+
+enum class Visibility(val modifier: KModifier) {
+    PUBLIC(KModifier.PUBLIC),
+    INTERNAL(KModifier.INTERNAL)
+}

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoBaseDeclaration.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/declaration/ProtoBaseDeclaration.kt
@@ -3,10 +3,12 @@ package io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.declaration
 import com.squareup.kotlinpoet.ClassName
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.Options
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoOptionsHolder
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoProject
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.ProtoVisibilityHolder
 import io.github.timortel.kmpgrpc.plugin.sourcegeneration.model.file.ProtoFile
 import org.antlr.v4.runtime.ParserRuleContext
 
-interface ProtoBaseDeclaration : ProtoOptionsHolder {
+interface ProtoBaseDeclaration : ProtoOptionsHolder, ProtoVisibilityHolder {
 
     /**
      * The name of this declaration
@@ -22,6 +24,9 @@ interface ProtoBaseDeclaration : ProtoOptionsHolder {
      * The file this declaration is located in
      */
     override val file: ProtoFile
+
+    override val project: ProtoProject
+        get() = file.project
 
     /**
      * The type of this declaration as it will be generated

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/file/ProtoFile.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/file/ProtoFile.kt
@@ -21,7 +21,7 @@ data class ProtoFile(
     val services: List<ProtoService>,
     override val options: List<ProtoOption>,
     val imports: List<ProtoImport>
-) : FileBasedDeclarationResolver, ProtoOptionsHolder {
+) : FileBasedDeclarationResolver, ProtoOptionsHolder, ProtoVisibilityHolder {
     lateinit var folder: ProtoFolder
     lateinit var protoPackage: ProtoPackage
 
@@ -33,7 +33,7 @@ data class ProtoFile(
             return folder.path + fileName
         }
 
-    val project: ProtoProject
+    override val project: ProtoProject
         get() = folder.project
 
     override val file: ProtoFile

--- a/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/BaseGenerationTest.kt
+++ b/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/BaseGenerationTest.kt
@@ -1,0 +1,16 @@
+package io.github.timortel.kotlin_multiplatform_grpc_plugin.generation
+
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.SourceTarget
+import org.slf4j.LoggerFactory
+
+abstract class BaseGenerationTest {
+
+    protected val logger = LoggerFactory.getLogger("DeprecatedOptionGenerationTest")
+
+    protected val targetMapAll = mapOf(
+        SourceTarget.Common to true,
+        SourceTarget.Js to true,
+        SourceTarget.Jvm to true,
+        SourceTarget.Native to true
+    )
+}

--- a/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/DeprecatedOptionGenerationTest.kt
+++ b/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/DeprecatedOptionGenerationTest.kt
@@ -9,30 +9,21 @@ import io.github.timortel.kotlin_multiplatform_grpc_plugin.createSingleFileProto
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
-import org.slf4j.LoggerFactory
 
-class DeprecatedOptionGenerationTest {
-
-    private val logger = LoggerFactory.getLogger("DeprecatedOptionGenerationTest")
-
-    private val targetMapAll = mapOf(
-        SourceTarget.Common to true,
-        SourceTarget.Js to true,
-        SourceTarget.Jvm to true,
-        SourceTarget.Native to true
-    )
+class DeprecatedOptionGenerationTest : BaseGenerationTest() {
 
     @Test
     fun `test generates deprecated annotation correctly`() {
         val fileMap = ProtoSourceGenerator.generateProtoFiles(
-            logger,
+            logger = logger,
             protoFolders = listOf(
                 createSingleFileProtoFolderFromResource(
                     classLoader = javaClass.classLoader,
                     fileName = "deprecated-test.proto"
                 )
             ),
-            shouldGenerateTargetMap = targetMapAll
+            shouldGenerateTargetMap = targetMapAll,
+            internalVisibility = false
         )
 
         val deprecatedProperties = listOf(

--- a/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/VisibilityTest.kt
+++ b/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/generation/VisibilityTest.kt
@@ -1,0 +1,56 @@
+package io.github.timortel.kotlin_multiplatform_grpc_plugin.generation
+
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.timortel.kmpgrpc.plugin.sourcegeneration.ProtoSourceGenerator
+import io.github.timortel.kotlin_multiplatform_grpc_plugin.createSingleFileProtoFolderFromResource
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class VisibilityTest : BaseGenerationTest() {
+
+    @Test
+    fun `test GIVEN the default visibility is public WHEN generating the code THEN all generated classes are public`() {
+        testDefaultCodeGeneration(internalVisibility = false, expectedModifier = KModifier.PUBLIC)
+    }
+
+    @Test
+    fun `test GIVEN the default visibility is internal WHEN generating the code THEN all generated classes are internal`() {
+        testDefaultCodeGeneration(internalVisibility = true, expectedModifier = KModifier.INTERNAL)
+    }
+
+    private fun testDefaultCodeGeneration(internalVisibility: Boolean, expectedModifier: KModifier) {
+        val fileMap = ProtoSourceGenerator.generateProtoFiles(
+            logger = logger,
+            protoFolders = listOf(
+                createSingleFileProtoFolderFromResource(
+                    classLoader = javaClass.classLoader,
+                    fileName = "declaration-test-basic.proto"
+                )
+            ),
+            shouldGenerateTargetMap = targetMapAll,
+            internalVisibility = internalVisibility
+        )
+
+        fileMap.values.forEach { files ->
+            files.forEach { file ->
+                file.members.forEach { member ->
+                    val message = "Expected modifiers to contain $expectedModifier, but not found. Member=$member"
+
+                    when (member) {
+                        is TypeSpec -> {
+                            Assertions.assertTrue(member.modifiers.any { it == expectedModifier }, message)
+                        }
+
+                        is FunSpec -> {
+                            Assertions.assertTrue(member.modifiers.any { it == expectedModifier }, message)
+                        }
+
+                        else -> throw IllegalStateException("Unknown member $member")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/validation/BaseValidationTest.kt
+++ b/kmp-grpc-plugin/src/test/java/io/github/timortel/kotlin_multiplatform_grpc_plugin/validation/BaseValidationTest.kt
@@ -17,11 +17,12 @@ abstract class BaseValidationTest {
             logger = logger,
             protoFolders = listOf(folder),
             shouldGenerateTargetMap = emptyMap(),
-            File(""),
-            File(""),
-            File(""),
-            File(""),
-            File("")
+            internalVisibility = false,
+            commonOutputFolder = File(""),
+            jvmOutputFolder = File(""),
+            jsOutputFolder = File(""),
+            wasmJsFolder = File(""),
+            nativeOutputDir = File("")
         )
     }
 }

--- a/kmp-grpc-plugin/src/test/resources/declaration-test-basic.proto
+++ b/kmp-grpc-plugin/src/test/resources/declaration-test-basic.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+option java_outer_classname = "DeclarationTestBasic";
+
+message SimpleMessage {
+
+}
+
+message NestingMessage {
+  message NestedMessage {
+
+  }
+
+  enum NestedEnum {
+    DEFAULT = 0;
+  }
+}
+
+enum SimpleEnum {
+  DEFAULT = 0;
+}
+
+service SomeService {
+
+}

--- a/kmp-grpc-wellknown-ext/build.gradle.kts
+++ b/kmp-grpc-wellknown-ext/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
 
 kotlin {
     applyDefaultHierarchyTemplate()
+    explicitApi()
 
     setupTargets(project)
 

--- a/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Any.kt
+++ b/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Any.kt
@@ -11,7 +11,7 @@ private const val DEFAULT_TYPE_URL_PREFIX = "type.googleapis.com"
 /**
  * @return a new [Any] message with the given [message] as content.
  */
-fun <T : Message> Any.Companion.wrap(message: T, typeUrlPrefix: String = DEFAULT_TYPE_URL_PREFIX): Any = any {
+public fun <T : Message> Any.Companion.wrap(message: T, typeUrlPrefix: String = DEFAULT_TYPE_URL_PREFIX): Any = any {
     type_url = getTypeUrl(message.fullName, typeUrlPrefix)
     value = message.serialize()
 }
@@ -21,7 +21,7 @@ fun <T : Message> Any.Companion.wrap(message: T, typeUrlPrefix: String = DEFAULT
  * @param deserializer typically the companion object of [T].
  * @return a message of type [T]
  */
-fun <T : Message, DES : MessageDeserializer<T>> Any.unwrap(deserializer: DES): T {
+public fun <T : Message, DES : MessageDeserializer<T>> Any.unwrap(deserializer: DES): T {
     return deserializer.deserialize(value)
 }
 
@@ -31,7 +31,7 @@ fun <T : Message, DES : MessageDeserializer<T>> Any.unwrap(deserializer: DES): T
  * @param message the companion object of [T]
  * @return if the type held by this object matches [T]
  */
-fun <T : Message> Any.isType(message: MessageCompanion<T>, typeUrlPrefix: String): Boolean {
+public fun <T : Message> Any.isType(message: MessageCompanion<T>, typeUrlPrefix: String): Boolean {
     return type_url == getTypeUrl(message.fullName, typeUrlPrefix)
 }
 
@@ -41,7 +41,7 @@ fun <T : Message> Any.isType(message: MessageCompanion<T>, typeUrlPrefix: String
  * @param message the companion object of [T]
  * @return if the type held by this object matches [T]
  */
-fun <T : Message> Any.isType(message: MessageCompanion<T>): Boolean {
+public fun <T : Message> Any.isType(message: MessageCompanion<T>): Boolean {
     return type_url.substringAfterLast('/') == message.fullName
 }
 
@@ -50,7 +50,7 @@ fun <T : Message> Any.isType(message: MessageCompanion<T>): Boolean {
  *
  * @return if the type held by this object matches the type of [message]
  */
-fun Any.isSameTypeAs(message: Message, typeUrlPrefix: String): Boolean {
+public fun Any.isSameTypeAs(message: Message, typeUrlPrefix: String): Boolean {
     return type_url == getTypeUrl(message.fullName, typeUrlPrefix)
 }
 
@@ -59,7 +59,7 @@ fun Any.isSameTypeAs(message: Message, typeUrlPrefix: String): Boolean {
  *
  * @return if the type held by this object matches the type of [message]
  */
-fun Any.isSameTypeAs(message: Message): Boolean {
+public fun Any.isSameTypeAs(message: Message): Boolean {
     return type_url.substringAfterLast('/') == message.fullName
 }
 

--- a/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Duration.kt
+++ b/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Duration.kt
@@ -8,26 +8,26 @@ import kotlin.time.Duration.Companion.seconds
 
 private const val NANOS_PER_SECOND = 1_000_000_000L
 
-fun Duration.Companion.ofSeconds(value: Long): Duration = duration {
+public fun Duration.Companion.ofSeconds(value: Long): Duration = duration {
     seconds = value
     nanos = 0
 }
 
-fun Duration.Companion.ofMillis(value: Long): Duration = Duration.fromDuration(value.milliseconds)
+public fun Duration.Companion.ofMillis(value: Long): Duration = Duration.fromDuration(value.milliseconds)
 
-fun Duration.Companion.fromDuration(value: kotlin.time.Duration): Duration = duration {
+public fun Duration.Companion.fromDuration(value: kotlin.time.Duration): Duration = duration {
     seconds = value.inWholeSeconds
     nanos = (value.inWholeNanoseconds - value.inWholeSeconds * NANOS_PER_SECOND).toInt()
 }
 
-fun Duration.toDuration(): kotlin.time.Duration {
+public fun Duration.toDuration(): kotlin.time.Duration {
     return seconds.seconds + nanos.nanoseconds
 }
 
-operator fun Duration.plus(other: Duration): Duration =
+public operator fun Duration.plus(other: Duration): Duration =
     Duration.fromDuration(toDuration() + other.toDuration())
 
-operator fun Duration.minus(other: Duration): Duration =
+public operator fun Duration.minus(other: Duration): Duration =
     Duration.fromDuration(toDuration() - other.toDuration())
 
-operator fun Duration.unaryMinus(): Duration = Duration.fromDuration(-toDuration())
+public operator fun Duration.unaryMinus(): Duration = Duration.fromDuration(-toDuration())

--- a/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Timestamp.kt
+++ b/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Timestamp.kt
@@ -8,15 +8,15 @@ import com.google.protobuf.timestamp
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-fun Timestamp.Companion.fromInstant(value: Instant): Timestamp = timestamp {
+public fun Timestamp.Companion.fromInstant(value: Instant): Timestamp = timestamp {
     seconds = value.epochSeconds
     nanos = value.nanosecondsOfSecond
 }
 
-fun Timestamp.toInstant(): Instant = Instant.fromEpochSeconds(seconds, nanos)
+public fun Timestamp.toInstant(): Instant = Instant.fromEpochSeconds(seconds, nanos)
 
-operator fun Timestamp.minus(other: Timestamp): Duration =
+public operator fun Timestamp.minus(other: Timestamp): Duration =
     Duration.fromDuration(toInstant() - other.toInstant())
 
-operator fun Timestamp.plus(other: Duration): Timestamp =
+public operator fun Timestamp.plus(other: Duration): Timestamp =
     Timestamp.fromInstant(toInstant() + other.toDuration())

--- a/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Wrappers.kt
+++ b/kmp-grpc-wellknown-ext/src/commonMain/kotlin/io/github/timortel/kmpgrpc/wkt/ext/Wrappers.kt
@@ -2,20 +2,20 @@ package io.github.timortel.kmpgrpc.wkt.ext
 
 import com.google.protobuf.*
 
-fun DoubleValue.Companion.of(value: Double): DoubleValue = doubleValue { this.value = value }
+public fun DoubleValue.Companion.of(value: Double): DoubleValue = doubleValue { this.value = value }
 
-fun FloatValue.Companion.of(value: Float): FloatValue = floatValue { this.value = value }
+public fun FloatValue.Companion.of(value: Float): FloatValue = floatValue { this.value = value }
 
-fun Int64Value.Companion.of(value: Long): Int64Value = int64Value { this.value = value }
+public fun Int64Value.Companion.of(value: Long): Int64Value = int64Value { this.value = value }
 
-fun UInt64Value.Companion.of(value: ULong): UInt64Value = uInt64Value { this.value = value }
+public fun UInt64Value.Companion.of(value: ULong): UInt64Value = uInt64Value { this.value = value }
 
-fun Int32Value.Companion.of(value: Int): Int32Value = int32Value { this.value = value }
+public fun Int32Value.Companion.of(value: Int): Int32Value = int32Value { this.value = value }
 
-fun UInt32Value.Companion.of(value: UInt): UInt32Value = uInt32Value { this.value = value }
+public fun UInt32Value.Companion.of(value: UInt): UInt32Value = uInt32Value { this.value = value }
 
-fun BoolValue.Companion.of(value: Boolean): BoolValue = boolValue { this.value = value }
+public fun BoolValue.Companion.of(value: Boolean): BoolValue = boolValue { this.value = value }
 
-fun StringValue.Companion.of(value: String): StringValue = stringValue { this.value = value }
+public fun StringValue.Companion.of(value: String): StringValue = stringValue { this.value = value }
 
-fun BytesValue.Companion.of(value: ByteArray): BytesValue = bytesValue { this.value = value }
+public fun BytesValue.Companion.of(value: ByteArray): BytesValue = bytesValue { this.value = value }


### PR DESCRIPTION
- Allow setting the default visibility of all generated files using `internalVisbility`
- Well Known Type Extension files now use `public` visibility by default. This can be changed to internal using `internalVisbility`.

Closes #86 
Closes #87 