### PR TITLE
Bugix: Fix string serialization in the presence of multibyte characters.

### DIFF
--- a/kmp-grpc-core/src/commonMain/kotlin/io/github/timortel/kmpgrpc/core/io/internal/CodedOutputStreamImpl.kt
+++ b/kmp-grpc-core/src/commonMain/kotlin/io/github/timortel/kmpgrpc/core/io/internal/CodedOutputStreamImpl.kt
@@ -30,6 +30,7 @@ import kotlinx.io.writeString
 import kotlinx.io.writeUByte
 import kotlinx.io.writeUIntLe
 import kotlinx.io.writeULongLe
+import okio.utf8Size
 
 internal class CodedOutputStreamImpl(private val sink: Sink) : CodedOutputStream {
 
@@ -321,7 +322,7 @@ internal class CodedOutputStreamImpl(private val sink: Sink) : CodedOutputStream
     }
 
     override fun writeStringNoTag(value: String) {
-        writeVarUInt32(value.length.toUInt())
+        writeVarUInt32(value.utf8Size().toUInt())
         sink.writeString(value)
     }
 

--- a/kmp-grpc-internal-test/src/commonTest/kotlin/io/github/timortel/kotlin_multiplatform_grpc_plugin/test/serialization/SelfMessageSerializationTest.kt
+++ b/kmp-grpc-internal-test/src/commonTest/kotlin/io/github/timortel/kotlin_multiplatform_grpc_plugin/test/serialization/SelfMessageSerializationTest.kt
@@ -9,6 +9,7 @@ import io.github.timortel.kmpgrpc.test.NonPackedTypesMessage
 import io.github.timortel.kmpgrpc.test.OneOfMessage
 import io.github.timortel.kmpgrpc.test.RepeatedLongMessage
 import io.github.timortel.kmpgrpc.test.ScalarTypes
+import io.github.timortel.kmpgrpc.test.SimpleMessage
 import io.github.timortel.kmpgrpc.test.Unknownfield
 import io.github.timortel.kmpgrpc.test.longMessage
 import io.github.timortel.kmpgrpc.test.messageWithSubMessage
@@ -125,6 +126,17 @@ class SelfMessageSerializationTest {
 
         val reconstructed = NonPackedTypesMessage.deserialize(msg.serialize())
 
+        assertEquals(msg, reconstructed)
+    }
+
+    @Test
+    fun testUtf8CharacterSerialization() {
+        val text = "ś, ß, \uD83D\uDC4B".repeat(20)
+        val msg = SimpleMessage(field1 = text)
+
+        val reconstructed = SimpleMessage.deserialize(msg.serialize())
+
+        assertEquals(text, reconstructed.field1)
         assertEquals(msg, reconstructed)
     }
 }


### PR DESCRIPTION
- Fix string length calculation when writing strings. 

Closes #94 