### PR TITLE
Bugfix: Workaround for nullable type generation; fix optional enum required size calculation

### DIFF
--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/RequiredSizePropertyExtension.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/message/extensions/serialization/RequiredSizePropertyExtension.kt
@@ -170,7 +170,7 @@ class RequiredSizePropertyExtension : BaseSerializationExtension() {
 
                         ProtoType.DefType.DeclarationType.ENUM -> {
                             CodeBlock.of(
-                                "%M(%L, %N.%N)",
+                                "%M(%L, this.%N.%N)",
                                 computeEnumSize,
                                 field.number,
                                 field.attributeName,

--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/type/ProtoType.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/model/type/ProtoType.kt
@@ -190,7 +190,7 @@ sealed interface ProtoType {
             return when (val decl = resolveDeclaration()) {
                 is ProtoEnum -> {
                     val defaultField = decl.defaultField
-                    CodeBlock.of("%T.%M", decl.className, defaultField.memberName)
+                    CodeBlock.of("%T.%N", decl.className, defaultField.name)
                 }
 
                 is ProtoMessage -> {


### PR DESCRIPTION
- Added workaround for nullable type generation (https://github.com/square/kotlinpoet/issues/2216)
- fix optional enum required size calculation

Closes #93 