### PR TITLE
Fix MemoryRawSource position tracking

### DIFF
--- a/kmp-grpc-core/src/nativeMain/kotlin/io/github/timortel/kmpgrpc/core/internal/MemoryRawSource.kt
+++ b/kmp-grpc-core/src/nativeMain/kotlin/io/github/timortel/kmpgrpc/core/internal/MemoryRawSource.kt
@@ -25,10 +25,13 @@ internal class MemoryRawSource(
         if (position >= size) return -1L
 
         val actualReadCount = minOf(byteCount.toULong(), size - position)
-
-        for (i in 0uL until actualReadCount) {
-            sink.writeUByte(pointer[i.toInt()])
+        val bytes = ByteArray(actualReadCount.toInt())
+        
+        for (i in 0 until actualReadCount.toInt()) {
+            bytes[i] = pointer[(position + i.toULong()).toInt()]
         }
+        
+        sink.writeByteArray(bytes)
 
         position += actualReadCount
         return actualReadCount.toLong()

--- a/kmp-grpc-internal-test/src/commonTest/kotlin/io/github/timortel/kotlin_multiplatform_grpc_plugin/test/MemoryRawSourceTest.kt
+++ b/kmp-grpc-internal-test/src/commonTest/kotlin/io/github/timortel/kotlin_multiplatform_grpc_plugin/test/MemoryRawSourceTest.kt
@@ -1,0 +1,34 @@
+package io.github.timortel.kotlin_multiplatform_grpc_plugin.test
+
+import io.github.timortel.kmpgrpc.core.internal.MemoryRawSource
+import kotlinx.cinterop.allocArray
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import platform.posix.memcpy
+import platform.posix.uint8_tVar
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MemoryRawSourceTest {
+
+    @Test
+    fun testReadAtMostToPositionTracking() {
+        val testData = "ABCDEFGHIJ".encodeToByteArray()
+        val memory = allocArray<uint8_tVar>(testData.size)
+        memcpy(memory, testData.refTo(0), testData.size.toULong())
+        
+        val source = MemoryRawSource(memory, testData.size.toULong())
+        
+        // First read
+        val sink1 = Buffer()
+        val bytesRead1 = source.readAtMostTo(sink1, 5L)
+        assertEquals(5L, bytesRead1)
+        assertEquals("ABCDE".encodeToByteArray().toList(), sink1.readByteArray().toList())
+        
+        // Second read - should continue from position 5
+        val sink2 = Buffer()
+        val bytesRead2 = source.readAtMostTo(sink2, 5L)
+        assertEquals(5L, bytesRead2)
+        assertEquals("FGHIJ".encodeToByteArray().toList(), sink2.readByteArray().toList())
+    }
+}


### PR DESCRIPTION
- Fix MemoryRawSource to properly track position when reading from memory
- Use writeByteArray instead of individual writeUByte calls for better performance
- Add a test
