### PR TITLE
Channel: add resetConnectBackoff method

### DIFF
--- a/kmp-grpc-core/src/androidJvmCommon/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
+++ b/kmp-grpc-core/src/androidJvmCommon/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
@@ -102,7 +102,6 @@ actual class Channel private constructor(val channel: ManagedChannel) {
 
     actual suspend fun shutdown() {
         channel.shutdown()
-
         awaitTermination()
     }
 
@@ -128,5 +127,9 @@ actual class Channel private constructor(val channel: ManagedChannel) {
                 t.interrupt()
             }
         }
+    }
+
+    actual fun resetConnectBackoff() {
+        channel.resetConnectBackoff()
     }
 }

--- a/kmp-grpc-core/src/commonMain/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
+++ b/kmp-grpc-core/src/commonMain/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
@@ -69,6 +69,7 @@ expect class Channel {
          */
         fun withClientIdentity(certificate: Certificate, key: PrivateKey): Builder
 
+
         /**
          * Construct the channel
          *
@@ -93,6 +94,15 @@ expect class Channel {
      */
     suspend fun shutdown()
 
+
+    /**
+     * For subchannels that are in TRANSIENT_FAILURE state, short-circuit the backoff timer and make them reconnect immediately
+     *
+     * This is primarily intended for Android users, where the network may experience frequent temporary drops. Rather than waiting for gRPC's name resolution and reconnect timers to elapse before reconnecting, the app may use this method as a mechanism to notify gRPC that the network is now available and a reconnection attempt may occur immediately.
+     *
+     * No-op if not supported by the implementation.
+     */
+    fun resetConnectBackoff()
     /**
      * Initiates a forceful shutdown of the gRPC channel. After invoking this method, no new calls
      * can be started, and ongoing calls are immediately canceled.

--- a/kmp-grpc-core/src/jsTargetCommon/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
+++ b/kmp-grpc-core/src/jsTargetCommon/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
@@ -66,4 +66,6 @@ actual class Channel private constructor(
     override fun cleanupResources() {
         client.close()
     }
+
+    actual fun resetConnectBackoff() {}
 }

--- a/kmp-grpc-core/src/nativeMain/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
+++ b/kmp-grpc-core/src/nativeMain/kotlin/io/github/timortel/kmpgrpc/core/Channel.kt
@@ -179,6 +179,8 @@ actual class Channel private constructor(
             init(ENABLE_TRACE_LOGGING)
         }
     }
+
+    actual fun resetConnectBackoff() {}
 }
 
 private fun installCertificates(


### PR DESCRIPTION
Adds resetConnectBackoff to Channel to allow resetting the connection backoff state and forcing the channel to retry connection attempts without waiting for the current backoff delay