### PR TITLE
`Bugfix`: Fix KOTLIN_IDIOMATIC code generation for oneof fields.

### DIFF
--- a/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/oneof/ActualProtoOneOfWriter.kt
+++ b/kmp-grpc-plugin/src/main/java/io/github/timortel/kmpgrpc/plugin/sourcegeneration/generators/protofile/oneof/ActualProtoOneOfWriter.kt
@@ -17,7 +17,7 @@ abstract class ActualProtoOneOfWriter : ProtoOneOfWriter(true) {
     override val attrs: List<KModifier> = listOf(KModifier.ACTUAL)
 
     override fun modifyOneOfProperty(builder: PropertySpec.Builder, oneOf: ProtoOneOf) {
-        builder.initializer(oneOf.name)
+        builder.initializer(oneOf.codeName)
     }
 
     override fun modifyParentClass(builder: TypeSpec.Builder, oneOf: ProtoOneOf) {


### PR DESCRIPTION
Closes #133 